### PR TITLE
Add changelog generator

### DIFF
--- a/clgen/cli.py
+++ b/clgen/cli.py
@@ -7,8 +7,8 @@ import logging
 
 import click
 
-from .command_groups.config import config_group
 from .config import Config
+from .config_commands import config_command_group
 
 __version__ = importlib.metadata.version("clgen")
 
@@ -25,4 +25,4 @@ def cli(ctx: click.Context, verbose: bool) -> None:
     ctx.obj = Config()
 
 
-cli.add_command(config_group)
+cli.add_command(config_command_group)

--- a/clgen/cli.py
+++ b/clgen/cli.py
@@ -4,13 +4,20 @@ Command-line interface for clgen.
 """
 import importlib.metadata
 import logging
+from pathlib import Path
 
 import click
 
 from .config import Config
 from .config_commands import config_command_group
+from .utils.cl_generator import ChangelogGenerator
+from .utils.git_helpers import get_commits
 
 __version__ = importlib.metadata.version("clgen")
+
+"""
+clgen
+"""
 
 
 @click.group()
@@ -25,4 +32,45 @@ def cli(ctx: click.Context, verbose: bool) -> None:
     ctx.obj = Config()
 
 
+"""
+clgen config
+"""
 cli.add_command(config_command_group)
+
+
+"""
+clgen generate
+"""
+
+
+@cli.command("generate")
+@click.option("--since", help="Start point for changelog (tag or commit SHA).")
+@click.option(
+    "--until", default="HEAD", show_default=True, help="End point for changelog."
+)
+@click.option("-o", "--output", type=click.Path(dir_okay=False), help="Write to file.")
+@click.pass_obj
+def generate(cfg: Config, since: str, until: str, output: str | None):
+    """Generate a changelog based on a git repository."""
+    if not cfg.openai_key:
+        raise click.UsageError(
+            "No OpenAI key set. Run `clgen config openai set-key <openai-key>` first."
+        )
+
+    repo_path = Path.cwd()
+    commits = get_commits(repo_path, since, until)
+    if not commits:
+        click.echo("No commits found in that range.", err=True)
+        raise SystemExit(1)
+
+    gen = ChangelogGenerator(
+        api_key=cfg.openai_key,
+        model=cfg.openai_model,
+    )
+    changelog_md = gen.generate(commits)
+
+    if output:
+        Path(output).write_text(changelog_md)
+        click.echo(f"Changelog written to {output}")
+    else:
+        click.echo(changelog_md)

--- a/clgen/command_groups/config/__init__.py
+++ b/clgen/command_groups/config/__init__.py
@@ -1,3 +1,0 @@
-from .config import config_group
-
-__all__ = ["config_group"]

--- a/clgen/command_groups/config/config.py
+++ b/clgen/command_groups/config/config.py
@@ -1,7 +1,0 @@
-from click import Group
-
-from .openai import openai_group
-
-config_group = Group("config", help="Manage settings.")
-
-config_group.add_command(openai_group)

--- a/clgen/command_groups/config/openai/__init__.py
+++ b/clgen/command_groups/config/openai/__init__.py
@@ -1,3 +1,0 @@
-from .openai import openai_group
-
-__all__ = ["openai_group"]

--- a/clgen/config_commands/__init__.py
+++ b/clgen/config_commands/__init__.py
@@ -1,0 +1,3 @@
+from .config import config_command_group
+
+__all__ = ["config_command_group"]

--- a/clgen/config_commands/config.py
+++ b/clgen/config_commands/config.py
@@ -1,0 +1,7 @@
+from click import Group
+
+from .openai import openai_command_group
+
+config_command_group = Group("config", help="Manage settings.")
+
+config_command_group.add_command(openai_command_group)

--- a/clgen/config_commands/openai.py
+++ b/clgen/config_commands/openai.py
@@ -3,10 +3,10 @@ from click import Group
 
 from clgen.config import Config
 
-openai_group = Group("openai", help="OpenAI API settings")
+openai_command_group = Group("openai", help="OpenAI API settings")
 
 
-@openai_group.command("get-key")
+@openai_command_group.command("get-key")
 @click.pass_obj
 def get_key(cfg: Config):
     """Show your current OpenAI key (masked)."""
@@ -14,7 +14,7 @@ def get_key(cfg: Config):
     click.echo("No key set." if not key else f"****{key[-4:]}")
 
 
-@openai_group.command("set-key")
+@openai_command_group.command("set-key")
 @click.argument("key")
 @click.pass_obj
 def set_key(cfg: Config, key: str):
@@ -23,14 +23,14 @@ def set_key(cfg: Config, key: str):
     click.echo("Key saved.")
 
 
-@openai_group.command("get-model")
+@openai_command_group.command("get-model")
 @click.pass_obj
 def get_model(cfg: Config):
     """Show your current OpenAI model."""
     click.echo(cfg.openai_model)
 
 
-@openai_group.command("set-model")
+@openai_command_group.command("set-model")
 @click.argument("model")
 @click.pass_obj
 def set_model(cfg: Config, model: str):

--- a/clgen/utils/cl_generator.py
+++ b/clgen/utils/cl_generator.py
@@ -1,0 +1,42 @@
+# clgen/generator.py
+import json
+from typing import Dict, Sequence
+
+from openai import OpenAI
+
+PROMPT = """
+You are an expert release‑note writer. Your task is to write a changelog based on a given list of commits (as JSON). Each commit contains the following:
+- commit: full commit hash
+- author: author name/email
+- date: commit date
+- summary: commit summary (subject)
+- body: commit body (message excluding subject)
+
+The changelog needs to be produced as Markdown.
+Your audience is developers that are using the project and the developers of project itself.
+
+The changelog follows the following format:
+
+- Title of the changelog. If a version is provided, use that. Otherwise, use the date from the latest commit.
+- Summary of the changes. Titled as "Summary". Summarize the changes in a few bullet points.
+- Full list of changes. Titled as "Release Notes". Divide sections by date of the commit with the section header as "Month Day, Year".
+    - Each commit should be summarized as a single bullet point.
+    - If the commit is trivial, it can be omitted.
+    - Include the commit hash at the end of the bullet point shortened to 5 characters - e.g. `(#12345)`
+    - Don't include the author of the commit in the bullet point.
+"""
+
+
+class ChangelogGenerator:
+    def __init__(self, api_key: str, model: str = "gpt-4"):
+        self.client = OpenAI(api_key=api_key)
+        self.model = model
+
+    def generate(self, commits: Sequence[Dict[str, str]]) -> str:
+        commits_block = json.dumps(commits, indent=2)
+        resp = self.client.responses.create(
+            model=self.model,
+            instructions=PROMPT,
+            input=commits_block,
+        )
+        return resp.output_text

--- a/clgen/utils/git_helpers.py
+++ b/clgen/utils/git_helpers.py
@@ -1,0 +1,56 @@
+import subprocess
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+def get_commits(
+    path: Path, since: Optional[str] = None, until: str = "HEAD"
+) -> List[Dict[str, str]]:
+    """
+    Retrieve git commits in structured format.
+
+    Returns a list of dicts with keys:
+      - commit: full commit hash
+      - author: author name/email
+      - date: commit date
+      - summary: commit summary (subject)
+      - body: commit body (message excluding subject)
+
+    :param path: path to the git repository
+    :param since: optional starting revision (e.g. 'v1.0.0')
+    :param until: ending revision (defaults to HEAD)
+    :return: list of commit dicts
+    """
+    # Format each commit as: hash, author, date, summary, body; record separator: \x1e; field separator: \x1f
+    fmt = "%H%x1f%an%x1f%ad%x1f%s%x1f%B%x1e"
+    args = ["git", "-C", str(path), "log", f"--pretty=format:{fmt}"]
+    if since:
+        args.append(f"{since}..{until}")
+
+    raw = subprocess.check_output(args, text=True)
+    entries = [entry for entry in raw.split("\x1e") if entry.strip()]
+
+    commits: List[Dict[str, str]] = []
+    for entry in entries:
+        parts = entry.split("\x1f")
+        if len(parts) < 5:
+            # Skip malformed entries
+            continue
+        commit_hash, author, date, summary, body = (
+            parts[0],
+            parts[1],
+            parts[2],
+            parts[3],
+            parts[4].rstrip(),
+        )
+        commits.append(
+            {
+                "commit": commit_hash,
+                "author": author,
+                "date": date,
+                "summary": summary,
+                "body": body,
+            }
+        )
+
+    return commits


### PR DESCRIPTION
implement changelog generation functionality
This PR adds the core functionality for generating changelogs from git commits using OpenAI's API. The changes include:

- Add new `generate` command to CLI with options for:
  - `--since`: Start point for changelog (tag or commit SHA)
  - `--until`: End point for changelog (defaults to HEAD)
  - `--output`: Optional output file path

- Add new utility modules:
  - `cl_generator.py`: Implements ChangelogGenerator class that:
    - Uses OpenAI API to generate changelog content
    - Formats commits into structured markdown
    - Handles API communication and response processing

  - `git_helpers.py`: Implements git commit retrieval with:
    - Structured commit data extraction
    - Support for commit range filtering
    - Proper error handling and data formatting

- Update CLI module to:
  - Integrate new generate command
  - Add proper error handling for missing OpenAI key
  - Support file output or stdout for changelog content

The implementation follows a clean architecture with separation of concerns between git operations, changelog generation, and CLI interface.